### PR TITLE
index: Removed unneeded (default) type="text/javascript" from <script> tag

### DIFF
--- a/doT/index.html
+++ b/doT/index.html
@@ -114,7 +114,7 @@ Then use require('dot') in your code.
 </p>
 <h3>For browsers</h3>
 Include the javascript file in your source:
-<p><code>&lt;script type="text/javascript" src="doT.js"&gt;&lt;/script&gt;</code></p>
+<p><code>&lt;script src="doT.js"&gt;&lt;/script&gt;</code></p>
 <h2>Sample</h2>
 <pre><code>// 1. Compile template function
 var tempFn = doT.template("&lt;h1&gt;Here is a sample template {{=it.foo}} &lt;/h1&gt;");


### PR DESCRIPTION
The type="text/javascript" is not needed by any browser and so the html spec has caught up: http://www.w3.org/TR/html5/scripting-1.html#attr-script-type

Like doT itself, concise.
