### PR TITLE
Fix mixed content errors

### DIFF
--- a/doT/index.html
+++ b/doT/index.html
@@ -258,9 +258,9 @@ First released on January 10, 2011
 
 </body>
 <script src="doT.min.js"></script>
-<script src="http://code.jquery.com/jquery.min.js"></script>
+<script src="https://code.jquery.com/jquery.min.js"></script>
 <!--[if lt IE 9]>
-<script src="http://bestiejs.github.com/json3/lib/json3.min.js"></script>
+<script src="https://bestiejs.github.com/json3/lib/json3.min.js"></script>
 <![endif]-->
 
 <script type="text/javascript">


### PR DESCRIPTION
This fixes `Blocked loading mixed active content “http://code.jquery.com/jquery.min.js”` errors (tested in Firefox)